### PR TITLE
Fix standalone AD join from a HA cluster

### DIFF
--- a/src/SambaNetJoin.pm
+++ b/src/SambaNetJoin.pm
@@ -118,6 +118,9 @@ sub ClusterPresent {
            $clone_id        = $1;
       }
     }
+    else {
+      return FALSE;
+    }
 
     $cluster_present    = TRUE;
     return TRUE;


### PR DESCRIPTION
A HA host with CTDB installed but not configured fails to join the
domain, as the ctdb crm resource cannot be located; (bnc#865445).

The AD join logic should fall-back to standalone (non-clustered)
membership unless a ctdb resource is configured.
