### PR TITLE
fix build: Revert "Add myself to the maintainers file"

### DIFF
--- a/MAINTAINER
+++ b/MAINTAINER
@@ -1,2 +1,1 @@
 Jiri Suchomel <jsuchome@suse.cz>
-David Disseldorp <ddiss@suse.de>


### PR DESCRIPTION
This reverts commit 4c0c1016936977ed6b68c55fbc27e7cc34fa5ea9.

The contents of MAINTAINER is slurped into the Makefile, where a
variable is assigned the result.

A multi-line MAINTAINER file results in:
    Makefile:254: **\* missing separator.  Stop.
