### PR TITLE
Fix CTDB resource primitive path regular expression

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 21 17:12:19 UTC 2014 - ddiss@suse.com
+
+- Fix CTDB resource primitive path regular expression; (bnc#892975).
+- 3.1.10
+
+-------------------------------------------------------------------
 Tue May 27 16:00:17 UTC 2014 - noel.power@suse.com
 
 - Mark some strings for translation; (bnc#877744)

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SambaNetJoin.pm
+++ b/src/modules/SambaNetJoin.pm
@@ -109,7 +109,7 @@ sub ClusterPresent {
 
     # find out resource and clone ids, to do later crm operations with
     my $show    = CRMCall ("configure save -");
-    if ($show =~ /primitive (\S+) ocf:heartbeat:CTDB/) {
+    if ($show =~ /primitive (\S+) (ocf:heartbeat:)?CTDB/) {
       $rsc_id = $1;
     }
     else {


### PR DESCRIPTION
Handle missing <class>:<provider>: primitive prefix (bnc#892975).
Bump to version 3.1.10.

Signed-off-by: David Disseldorp ddiss@suse.de
