### PR TITLE
Support separately defined Samba resources

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 22 17:48:20 UTC 2014 - ddiss@suse.com
+
+- Support separately defined Samba resources; don't manipulate the
+  ctdb_manages_winbind parameter during join; (bnc#892982).
+- 3.1.11
+
+-------------------------------------------------------------------
 Thu Aug 21 17:12:19 UTC 2014 - ddiss@suse.com
 
 - Fix CTDB resource primitive path regular expression; (bnc#892975).

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        3.1.10
+Version:        3.1.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SambaNetJoin.pm
+++ b/src/modules/SambaNetJoin.pm
@@ -169,11 +169,6 @@ sub PrepareCTDB {
 
     return FALSE unless $self->ClusterPresent (0);
 
-    # 3. Run crm configure edit and search for the ctdb resource. Add the following line:
-    # ctdb_manages_winbind="false"
-
-    CRMCall ("resource param $rsc_id set ctdb_manages_winbind no");
-
     # 4. save winbind into  /etc/nsswitch.conf
     # 5. Restart the NSC daemon:
     SambaWinbind->AdjustNsswitch (TRUE, TRUE);
@@ -207,16 +202,8 @@ sub CleanupCTDB {
 
     return TRUE unless $cleanup_needed;
 
-    # 10. Change the ctdb_manages_winbind option:
-
-    # a. Stop the ctdb resource:
-    CRMCall ("resource stop $rsc_id");
-
-    # b. Change the value from false to true: ctdb_manages_winbind="true"
-    CRMCall ("resource param $rsc_id set ctdb_manages_winbind yes");
-
-    # c. Restart the ctdb resource:
-    CRMCall ("resource start $rsc_id");
+    # Restart the ctdb resource, winbind will also be restarted with grouping:
+    CRMCall ("resource restart $rsc_id");
 
     $cleanup_needed     = FALSE;
 


### PR DESCRIPTION
Don't manipulate the ctdb_manages_winbind parameter during join;
(bnc#892982).
- 3.1.11

Signed-off-by: David Disseldorp ddiss@suse.de
