### PR TITLE
Support non-default ctdbd socket paths

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 28 13:20:17 UTC 2014 - ddiss@suse.com
+
+- Support non-default ctdbd socket paths; (bnc#893154).
+- 3.1.12
+
+-------------------------------------------------------------------
 Fri Aug 22 17:48:20 UTC 2014 - ddiss@suse.com
 
 - Support separately defined Samba resources; don't manipulate the

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        3.1.11
+Version:        3.1.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SambaNetJoin.pm
+++ b/src/modules/SambaNetJoin.pm
@@ -177,12 +177,18 @@ sub PrepareCTDB {
     # 7. Cleanup CTDB:
     CRMCall ("resource cleanup $rsc_id");
 
-    # 8. Wait until the unhealty status disappears.
+    # 8. Wait until the unhealthy status disappears.
     my $start   = time;
     my $wait    = 60; # 1 minute timeout
+    my $ctdbd_socket = SambaConfig->GlobalGetStr("ctdbd socket", undef);
+    my $ctdb_args = "";
+    if (defined $ctdbd_socket) {
+      $ctdb_args = "--socket=$ctdbd_socket";
+    }
 
     while (time<$start+$wait) {
-      my $out     = SCR->Execute(".target.bash_output", "/usr/bin/ctdb status");
+      my $out = SCR->Execute(".target.bash_output",
+			     "/usr/bin/ctdb $ctdb_args status");
       last if ($out->{"exit"} == 0);
       sleep (1); #0.5);
     }


### PR DESCRIPTION
Read the ctdbd socket path from smb.conf, rather than assuming the
default; (bnc#893154).
- 3.1.12

Signed-off-by: David Disseldorp ddiss@suse.de
