### PR TITLE
fix Workgroup being overwritten by realm name. bnc#902302

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 30 13:55:23 UTC 2014 - nopower@suse.com
+
+- Don't update Workgroup with realm name invoking 
+  yast samba-client winbind enable; (bnc#902302)
+- 3.1.14
+
+-------------------------------------------------------------------
 Mon Sep 22 15:01:33 UTC 2014 - ddiss@suse.com
 
 - Ensure nmbd is restarted following nmbstatus lookup; (bnc#895319).

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        3.1.13
+Version:        3.1.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/samba-client.rb
+++ b/src/clients/samba-client.rb
@@ -190,7 +190,6 @@ module Yast
       #(bnc#845878)
       domain    = Samba.GetWorkgroupOrRealm
       SambaAD.ReadADS(domain)
-      Samba.SetWorkgroup(domain)
       SambaAD.ReadRealm
 
       Samba.SetWinbind(command == "enable")


### PR DESCRIPTION
don't set the Workgroup with the name returned from Samba.GetWorkgroupOrRealm
otherwise for non ADS config the realm/domain name will be set for Workgroup.
