### PR TITLE
pass osVersion and osName (and empty osServicePack) to join command

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 12 16:53:48 UTC 2015 - nopower@suse.com
+
+- When joining domain provide osName & osVer arguments to "net ads join"
+  (bnc#873922).
+- 3.1.15
+
+-------------------------------------------------------------------
 Thu Oct 30 13:55:23 UTC 2014 - nopower@suse.com
 
 - Don't update Workgroup with realm name invoking 

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        3.1.14
+Version:        3.1.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/samba-client.rb
+++ b/src/clients/samba-client.rb
@@ -44,6 +44,7 @@ module Yast
       Yast.import "Samba"
       Yast.import "SambaAD"
       Yast.import "SambaNetJoin"
+      Yast.import "OSRelease"
 
       # The main ()
       Builtins.y2milestone("----------------------------------------")
@@ -260,13 +261,16 @@ module Yast
         domain = SambaAD.GetWorkgroup(domain)
         SambaAD.ReadRealm
       end
-
+      relname = OSRelease.ReleaseName
+      relver = OSRelease.ReleaseVersion
       result = SambaNetJoin.Join(
         domain,
         "member",
         Ops.get_string(options, "user"),
         Ops.get_string(options, "password", ""),
-        Ops.get_string(options, "machine")
+        Ops.get_string(options, "machine"),
+        relname,
+        relver
       )
       if result == nil
         # translators: result message for joindomain command line action

--- a/src/include/samba-client/routines.rb
+++ b/src/include/samba-client/routines.rb
@@ -45,6 +45,8 @@ module Yast
       Yast.import "SambaNetJoin"
       Yast.import "SambaNmbLookup"
       Yast.import "SambaAD"
+      Yast.import "OSRelease"
+
     end
 
     # Allow user to type in a user/password pair in a popup.
@@ -255,13 +257,17 @@ module Yast
 
       # cancelled the domain joining
       return :fail if passwd == nil
+      relname = OSRelease.ReleaseName
+      relver = OSRelease.ReleaseVersion
       # try to join the domain
       error = SambaNetJoin.Join(
         workgroup,
         "member",
         Ops.get(passwd, "user"),
         Ops.get(passwd, "password", ""),
-        Ops.get(passwd, "machine")
+        Ops.get(passwd, "machine"),
+        relname,
+        relver
       )
 
       if error != nil

--- a/src/modules/Samba.rb
+++ b/src/modules/Samba.rb
@@ -53,6 +53,7 @@ module Yast
       Yast.import "String"
       Yast.import "Summary"
       Yast.import "SuSEFirewall"
+      Yast.import "OSRelease"
 
 
       # Data was modified?
@@ -803,6 +804,8 @@ module Yast
         end
         # join the domain during autoinstallation
         if @password_data != {}
+          relname = OSRelease.ReleaseName
+          relver = OSRelease.ReleaseVersion
           SambaNetJoin.Join(
             SambaConfig.GlobalGetStr("workgroup", ""),
             "member",
@@ -816,7 +819,9 @@ module Yast
               "password",
               Ops.get(@password_data, "passwd", "")
             ),
-            Ops.get(@password_data, "machine")
+            Ops.get(@password_data, "machine"),
+            relname,
+            relver
           )
         end
       end

--- a/src/modules/SambaNetJoin.pm
+++ b/src/modules/SambaNetJoin.pm
@@ -279,9 +279,10 @@ sub Test {
 # @param machine	machine account to join into (fate 301320)
 # @return string	an error message or nil if successful
 BEGIN{$TYPEINFO{Join}=[
-    "function","string","string","string","string","string","string"]}
+    "function","string","string","string","string","string","string", "string", "string"]}
 sub Join {
-    my ($self, $domain, $join_level, $user, $passwd, $machine) = @_;
+    my ($self, $domain, $join_level, $user, $passwd, $machine, $release_name,
+        $release_version) = @_;
     
     my $netbios_name	= SambaConfig->GlobalGetStr("netbios name", undef);
     my $server		= SambaAD->ADS ();
@@ -336,7 +337,9 @@ sub Join {
 #	. (($protocol ne "ads" && $netbios_name)?" -n '$netbios_name'":"")
 # FIXME check if netbios name can be used with AD
 	. ($netbios_name  ? " -n '$netbios_name'" : "")
-	. " -U '" . String->Quote ($user) . "%" . String->Quote ($passwd) . "'";
+	. " -U '" . String->Quote ($user) . "%" . String->Quote ($passwd) . "'"
+	. " osVer='" . String->Quote ($release_version) . "'"
+	. " osName='" . String->Quote ($release_name) . "'";
 
     if ($machine) {
 	$machine	=~ s/dc=([^,]*)//gi; # remove DC=* parts


### PR DESCRIPTION
This change ensures osVersion and osName are visible in windows admin
tool for the 'joined' computer