### PR TITLE
update idmap config syntax

### DIFF
--- a/src/modules/SambaWinbind.pm
+++ b/src/modules/SambaWinbind.pm
@@ -57,8 +57,8 @@ sub AdjustSambaConfig {
     if ($status) {
 	# if turning on and there is no values set, use default
 	SambaConfig->GlobalUpdateMap({
-	    "idmap uid" => "10000-20000",
-	    "idmap gid" => "10000-20000"
+	    "idmap config * : backend" => "tdb",
+	    "idmap config * : range"   => "10000-20000"
 	});
 	SambaConfig->GlobalSetStr ("template shell", "/bin/bash");
     }

--- a/testsuite/tests/SambaWinbind.out
+++ b/testsuite/tests/SambaWinbind.out
@@ -4,8 +4,8 @@ $VAR1 = 1;
 
 SambaConfig: [global]
 SambaConfig: _modified = 1
-SambaConfig: idmap gid = 10000-20000
-SambaConfig: idmap uid = 10000-20000
+SambaConfig: idmap config * : backend = tdb
+SambaConfig: idmap config * : range = 10000-20000
 
 Nsswitch::WriteDB(passwd, [files,nis])
 Nsswitch::WriteDB(group, [files,ldap,nis])


### PR DESCRIPTION
idmap uid/gid is obsolete

samba tools like smbclient now warn about it:

```
linux-fp5a:~ # smbclient //localhost/users -U aaptel-ad%'xyz'
WARNING: The "idmap gid" option is deprecated
WARNING: The "idmap uid" option is deprecated
```

This commit simply changes what is written to the new syntax.

It probably needs more work to detect the old syntax in the case of reading a old smb.conf but I'm not even sure this is actually a usecase we have to handle? (we always overwrite the file no?)
