### PR TITLE
add checkbox for the net ads join --no-dns-updates switch

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Aug 19 14:00:29 UTC 2016 - aaptel@suse.com
+
+ - Add checkbox for net ads join --no-dns-updates; (bsc#991564).
+ 
+-------------------------------------------------------------------
 Tue Jun  7 11:06:52 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/src/include/samba-client/dialogs.rb
+++ b/src/include/samba-client/dialogs.rb
@@ -533,7 +533,13 @@ module Yast
                 Ops.get_string(pw_data, "machine", "") != nil ?
                   Ops.get_string(pw_data, "machine", "") :
                   ""
-              )
+              ),
+              CheckBox(
+                Id(:update_dns),
+                Opt(:hstretch),
+                _('Update DNS'),
+                !!pw_data['update_dns'],
+              ),
             )
           ),
           VSpacing(),
@@ -760,6 +766,9 @@ module Yast
               val = Convert.to_string(UI.QueryWidget(Id(key), :Value))
               Ops.set(Samba.password_data, key, val) if val != nil && val != ""
             end
+            # update_dns is a boolean, using to_string is incorrect
+            Samba.password_data["update_dns"] = UI.QueryWidget(Id(:update_dns), :Value)
+
             if Convert.to_string(UI.QueryWidget(Id(:ads), :Value)) != ""
               SambaAD.SetADS(
                 Convert.to_string(UI.QueryWidget(Id(:ads), :Value))

--- a/src/include/samba-client/routines.rb
+++ b/src/include/samba-client/routines.rb
@@ -60,6 +60,7 @@ module Yast
       default_id = "default_entry"
       # default value of Machine Account
       default_entry = Item(Id(default_id), _("(default)"))
+      update_dns = Empty()
       if SambaAD.ADS != "" && what != :leave
         machines = [default_entry]
         machine_term = HBox(
@@ -77,6 +78,7 @@ module Yast
           ),
           VBox(Label(""), PushButton(Id(:acquire), _("O&btain list")))
         )
+        update_dns = CheckBox(Id(:update_dns), Opt(:hstretch), _('Update DNS'), true)
       end
       UI.OpenDialog(
         Opt(:decorated),
@@ -90,6 +92,7 @@ module Yast
             InputField(Id(:user), Opt(:hstretch), _("&Username"), defaultuser),
             Password(Id(:passwd), Opt(:hstretch), Label.Password),
             machine_term,
+            update_dns,
             VSpacing(0.2),
             ButtonBox(
               PushButton(Id(:ok), Opt(:default), Label.OKButton),
@@ -146,7 +149,7 @@ module Yast
         end
       end
 
-      result = ret == :ok ? { "user" => user, "password" => pass } : nil
+      result = ret == :ok ? { "user" => user, "password" => pass, "update_dns" => UI.QueryWidget(Id(:update_dns), :Value) } : nil
       if SambaAD.ADS != "" && ret == :ok && what != :leave
         machine = Convert.to_string(UI.QueryWidget(Id(:machines), :Value))
         Ops.set(result, "machine", machine) if machine != default_id
@@ -267,7 +270,8 @@ module Yast
         Ops.get(passwd, "password", ""),
         Ops.get(passwd, "machine"),
         relname,
-        relver
+        relver,
+        passwd["update_dns"]
       )
 
       if error != nil

--- a/src/modules/Samba.rb
+++ b/src/modules/Samba.rb
@@ -821,7 +821,8 @@ module Yast
             ),
             Ops.get(@password_data, "machine"),
             relname,
-            relver
+            relver,
+            !!@password_data['update_dns']
           )
         end
       end
@@ -959,7 +960,7 @@ module Yast
             Ops.get_string(settings, ["active_directory", "kdc"], "")
           )
         elsif key == "join"
-          @password_data = Ops.get_map(settings, "join", {})
+          @password_data = Ops.get_map(settings, "join", {'update_dns' => true})
         elsif key == "mkhomedir"
           SetMkHomeDir(Ops.get_boolean(settings, "mkhomedir", @mkhomedir))
         elsif key == "disable_dhcp_hostname"

--- a/src/modules/SambaNetJoin.pm
+++ b/src/modules/SambaNetJoin.pm
@@ -282,7 +282,7 @@ BEGIN{$TYPEINFO{Join}=[
     "function","string","string","string","string","string","string", "string", "string"]}
 sub Join {
     my ($self, $domain, $join_level, $user, $passwd, $machine, $release_name,
-        $release_version) = @_;
+        $release_version, $update_dns) = @_;
     
     my $netbios_name	= SambaConfig->GlobalGetStr("netbios name", undef);
     my $server		= SambaAD->ADS ();
@@ -340,6 +340,10 @@ sub Join {
 	. " -U '" . String->Quote ($user) . "%" . String->Quote ($passwd) . "'"
 	. " osVer='" . String->Quote ($release_version) . "'"
 	. " osName='" . String->Quote ($release_name) . "'";
+
+    if ($server ne "" && !$update_dns) {
+        $cmd .= " --no-dns-updates"
+    }
 
     if ($machine) {
 	$machine	=~ s/dc=([^,]*)//gi; # remove DC=* parts


### PR DESCRIPTION
SLE12SP2 net ads join utility has a new --no-dns-updates option (bsc#991564) this change adds a checkbox in the AD join popup and the autoyast UI to reflect that.
