### PR TITLE
Enable yast to create temporary smb.conf based on existing /etc/samba…

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 26 09:37:23 UTC 2017 - nopower@suse.com
+
+- Enable yast to create temporary smb.conf based on existing
+  contents of /etc/samba/smb.conf; (bsc#1039764).
+- 3.1.19
+
+-------------------------------------------------------------------
 Tue Oct 11 13:23:28 UTC 2016 - nopower@suse.com
 
 - Adjust vertical spacing in Server Directories Frame; (bsc#988901).

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        3.1.18
+Version:        3.1.19
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
…/smb.conf

Bug: bsc#1039764

Added new function SambaConfig.GetGlobalCfgStr which returns the global
configuration (based on SambaConfig.pm internal and maybe as yet unwritten)
model a string but allows you pass in a hash to overwrite the existing
configuration values

Signed-off-by: Noel Power <noel.power@suse.com>