### PR TITLE
Fix reading the permitted group to create "user shares"

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 26 14:02:33 UTC 2018 - Samuel Cabrero <scabrero@suse.de>
+
+- Fix reading the permitted group to create "user shares";
+  (bsc#1107574).
+- 4.0.3
+
+-------------------------------------------------------------------
 Mon Aug 20 14:06:28 CEST 2018 - schubi@suse.de
 
 - Switched license in spec file from SPDX2 to SPDX3 format.

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Samba.rb
+++ b/src/modules/Samba.rb
@@ -361,7 +361,7 @@ module Yast
           SCR.Execute(
             path(".target.bash_output"),
             Builtins.sformat(
-              "getent group | grep \":%1:\" | /usr/bin/cut -f 1 -d :",
+              "getent group %1 | /usr/bin/cut -f 1 -d :",
               Ops.get_integer(stat, "gid", 100)
             )
           )


### PR DESCRIPTION
The ReadSharesSetting function tries to find the permitted group's gid in
the groups listed by 'getent group'. Since samba 4.2.0 winbind does not
enumerate the domain groups, so if the permitted group is a domain group
it is not found and the field is left empty, falling back to the default
"users" groups when saving the configuration. To fix this, Call "getent
group" with the gid number as argument instead parsing the output.

Signed-off-by: Samuel Cabrero <scabrero@suse.de>