### PR TITLE
Fix join fails with 'Failed to join domain: Invalid configuration'

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 04 19:00:44 UTC 2019 - David Mulder <dmulder@suse.com>
+
+- Fix join fails with 'Failed to join domain: Invalid configuration';
+  (bsc#1131607).
+- 4.1.2
+
+-------------------------------------------------------------------
 Tue Feb  5 20:12:18 UTC 2019 - David Mulder <dmulder@suse.com>
 
 - Perform the workgroup lookup using samba python bindings;

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SambaAPI.py
+++ b/src/modules/SambaAPI.py
@@ -3,12 +3,11 @@ import_module('PackageSystem')
 import_module('Package')
 from yast import PackageSystem, Package
 if not PackageSystem.Installed('samba-python3'):
-    if Package.InstallAll(['samba-python3']):
-        from samba.net import Net
-        from samba.credentials import Credentials
-        from samba.dcerpc import nbt
-    else:
+    if not Package.InstallAll(['samba-python3']):
         raise ImportError("Failed to install samba python bindings samba-python3")
+from samba.net import Net
+from samba.credentials import Credentials
+from samba.dcerpc import nbt
 
 # Global response to net.finddc()
 cldap_ret = None


### PR DESCRIPTION
The samba imports are within a if block that doesn't always execute.
Bug 1131607.