### PR TITLE
 Jira: SLE-5632: Stop using deprecated idmap options

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May  7 16:55:53 UTC 2019 - David Mulder <dmulder@suse.com>
+
+- Stop using deprecated idmap options; (jsc#SLE-5632); (jsc#SLE-6283);
+- 3.1.21
+
+-------------------------------------------------------------------
 Wed Sep 26 14:02:33 UTC 2018 - Samuel Cabrero <scabrero@suse.de>
 
 - Fix reading the permitted group to create "user shares";

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        3.1.20
+Version:        3.1.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/samba-client.rb
+++ b/src/clients/samba-client.rb
@@ -190,10 +190,11 @@ module Yast
       # read AD settings, so the write command does not fallback to non-AD default
       #(bnc#845878)
       domain    = Samba.GetWorkgroupOrRealm
+      workgroup = Samba.GetWorkgroup
       SambaAD.ReadADS(domain)
       SambaAD.ReadRealm
 
-      Samba.SetWinbind(command == "enable")
+      Samba.SetWinbind(command == "enable", workgroup)
     end
 
     # Check domain membership.

--- a/src/modules/Samba.rb
+++ b/src/modules/Samba.rb
@@ -689,13 +689,13 @@ module Yast
     # Set a windind status
     #
     # @param group	a new winbind status
-    def SetWinbind(status)
+    def SetWinbind(status, workgroup)
       if status != @winbind_enabled
         @modified = true
         @winbind_enabled = status
       end
       SambaAD.AdjustSambaConfig(status)
-      SambaWinbind.AdjustSambaConfig(status)
+      SambaWinbind.AdjustSambaConfig(status, workgroup)
 
       nil
     end
@@ -983,7 +983,8 @@ module Yast
         "winbind",
         Ops.get_boolean(settings, ["global", "winbind"], false)
       )
-      SetWinbind(winbind) if winbind != nil
+      @workgroup = Ops.get_string(settings, ["global", "workgroup"], "")
+      SetWinbind(winbind, @workgroup) if winbind != nil
 
       SambaConfig.Import(sections) if sections != []
 

--- a/src/scrconf/cfg_smbconf.scr
+++ b/src/scrconf/cfg_smbconf.scr
@@ -26,7 +26,7 @@
 	// we need to exclude ; because of the second matching rule
 	"params" : [
 	    $[
-		"match" : [ "^[ \t]*([a-z0-9:_ ]*[a-z])[ \t]*=[ \t]*(.*[^ \t])[ \t]*$" , "\t%s = %s"],
+		"match" : [ "^[ \t]*([a-z0-9:_ \*]*[a-z])[ \t]*=[ \t]*(.*[^ \t])[ \t]*$" , "\t%s = %s"],
 	    ], $[
 		// this is a special type for commenting out the values
 //		"match" : [ "^[;#]+[ \t]*([a-z ]*[a-z])[ \t]*=[ \t]*(.*[^ \t])[ \t]*$" , "#\t%s = %s"],


### PR DESCRIPTION
Fix 1133434: yast-samba-client fails to parse new idmap settings