### PR TITLE
Fix bsc#1144828: Adjust workgroup/domain name parsing for newer samba.

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  8 10:24:29 UTC 2019 - Noel Power <nopower@suse.com>
+
+- Adjust ADDomain2Workgroup function to parse workgroup/domain
+  name for newer samba versions; (bsc#1144828).
+- 3.1.22
+
+-------------------------------------------------------------------
 Tue May  7 16:55:53 UTC 2019 - David Mulder <dmulder@suse.com>
 
 - Stop using deprecated idmap options; (jsc#SLE-5632); (jsc#SLE-6283);

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        3.1.21
+Version:        3.1.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SambaAD.pm
+++ b/src/modules/SambaAD.pm
@@ -293,7 +293,7 @@ sub ADDomain2Workgroup {
 
     return "" if $server eq "";
 
-    my $out	= SCR->Execute (".target.bash_output", "net ads lookup -S $server | grep 'Pre-Win2k Domain' | cut -f 2");
+    my $out	= SCR->Execute (".target.bash_output", "net ads lookup -S $server | grep 'Pre-Win2k Domain' | awk '{print \$3}'");
 
     y2debug ("net ads lookup -S $server: ", Dumper ($out));
     if ($out->{"exit"} ne 0 || $out->{"stdout"} eq "") {


### PR DESCRIPTION
The format of the line output from the 'net' command has changed
slightly in newer versions of samba.

older:

Pre-Win2k Domain:	domainname

newer:
Pre-Win2k Domain: domainname

With the new format SambaAD.pm the parsing fails and the workgroup is
resolved to the whole line.

e.g.

old:
echo -e "Pre-Win2k Domain:\tdomainname" | cut -f2
results in 'domainname;

new:
echo -e "Pre-Win2k Domain: domainname" | cut -f2
results in 'Pre-Win2k Domain: domainname'

This change makes the parsing work for old and new formats.

e.g.

old:
echo -e "Pre-Win2k Domain:\tdomainname" | awk '{print $3}'
results in 'domainname;

new:
echo -e "Pre-Win2k Domain: domainname" | awk '{print $3}'
results in 'domainname'

Signed-off-by: Noel Power <noel.power@suse.com>