### PR TITLE
Do not stop nmbd while running nmbstatus

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 15 11:38:38 UTC 2020 - Samuel Cabrero <scabrero@suse.de>
+
+- Do not stop nmbd while nmbstatus is running, it is not necessary
+  anymore; (bsc#1158916);
+- 4.1.3
+
+-------------------------------------------------------------------
 Thu Apr 04 19:00:44 UTC 2019 - David Mulder <dmulder@suse.com>
 
 - Fix join fails with 'Failed to join domain: Invalid configuration';

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        4.1.2
+Version:        4.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
For historical reasons nmbd was stopped before running nmbstatus,
otherwise only localhost was returned. This is not necessary anymore.

Release 4.1.3

Signed-off-by: Samuel Cabrero <scabrero@suse.de>