### PR TITLE
Switch from file based krb5 ccache to kernel keyring.

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 28 09:30:17 UTC 2022 - Samuel Cabrero <scabrero@suse.de>
+
+- Switch from file based krb5 ccache to kernel keyring;
+  (bsc#1109830);
+- 4.4.3
+
+-------------------------------------------------------------------
 Wed Dec  8 14:46:40 UTC 2021 - Noel Power <nopower@suse.com>
 
 - With latest versions of samba (>=4.15.0) calling 'net ads lookup'

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 - Samba Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/Kerberos.rb
+++ b/src/modules/Kerberos.rb
@@ -731,7 +731,7 @@ module Yast
         # change the default ccache name
         WriteKrb5ConfValue(
           path(".etc.krb5_conf.v.libdefaults.default_ccache_name"),
-          "FILE:/tmp/krb5cc_%{uid}"
+          "KEYRING:persistent:%{uid}"
         )
 
         # write the mapping domain-realm

--- a/src/modules/SambaAD.pm
+++ b/src/modules/SambaAD.pm
@@ -348,7 +348,7 @@ sub AdjustSambaConfig {
     });
     SambaConfig->WinbindGlobalSetMap({
 	"krb5_auth"			=> $remove ? undef : "yes",
-	"krb5_ccache_type"		=> $remove ? undef : "FILE"
+	"krb5_ccache_type"		=> $remove ? undef : "KEYRING"
     });
     if ($status) {
 	if (SambaConfig->GlobalGetTruth ("domain logons", 0)) {


### PR DESCRIPTION
Follow changes to krb5 package in Tumbleweed to fix bsc#1109830.

Signed-off-by: Samuel Cabrero <scabrero@suse.de>