### PR TITLE
Bsc1197936 sle12sp5

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 27 08:47:46 UTC 2022 - Noel Power <nopower@suse.com>
+
+- Use translation macro for range settings expert details text;
+  (bsc#1197936).
+- 3.1.24
+
+-------------------------------------------------------------------
 Tue Jan 11 15:47:59 UTC 2022 - Noel Power <nopower@suse.com>
 
 - With latest versions of samba (>=4.15.0) calling 'net ads lookup'

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        3.1.23
+Version:        3.1.24
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/samba-client/dialogs.rb
+++ b/src/include/samba-client/dialogs.rb
@@ -239,6 +239,7 @@ module Yast
         Item(Id(method), method, method == idmap_domain_backend)
       end
 
+     ranges_text = _("If you're unsure of which backend to choose, please <a href=\"https://www.suse.com/support/kb/doc/?id=7007006\">read kb article 7007006</a>. For the tdb, ad, rid, and autorid idmap backend details, see the idmap_tdb(8), idmap_ad(8), idmap_rid(8) and idmap_autorid(8) man pages. Please refer to the smb.conf(5) man page for further options which may need to be manually configured. For other idmap backends, see the idmap_tdb2(8), idmap_ldap(8), idmap_hash(8), idmap_nss(8) and idmap_rfc2307(8) man pages.")
       contents = HBox(
         HSpacing(3),
         VBox(
@@ -264,7 +265,7 @@ module Yast
               IntField(Id(:domain_max), _("M&aximum"), 0, 999999, domain_max),
               ComboBox(Id(:backend), _("Back&end"), idmap_domain_backends),
             ),
-            RichText("If you're unsure of which backend to choose, please <a href=\"https://www.suse.com/support/kb/doc/?id=7007006\">read kb article 7007006</a>. For the tdb, ad, rid, and autorid idmap backend details, see the idmap_tdb(8), idmap_ad(8), idmap_rid(8) and idmap_autorid(8) man pages. Please refer to the smb.conf(5) man page for further options which may need to be manually configured. For other idmap backends, see the idmap_tdb2(8), idmap_ldap(8), idmap_hash(8), idmap_nss(8) and idmap_rfc2307(8) man pages.")
+            RichText(ranges_text)
             )
           ),
           VSpacing(0.2),


### PR DESCRIPTION
## Problem

Missing translation text

*Advanced configuration detailed description text is untranslated
 
- [bnc#1197936](https://bugzilla.suse.com/show_bug.cgi?id=1197936)


## Solution

*Added _() macro to text

Note: Affects 

- SLE12-SP5 (this merge request)
- SLE15-SP2
- SLE15-SP3
- SLE15-SP4
