### PR TITLE
Enable pam_mount also for gdm-password service (bsc#1204830)

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov  4 10:16:54 UTC 2022 - Samuel Cabrero <scabrero@suse.de>
+
+- Enable pam_mount also for gdm-password service; (bsc#1204830);
+- 4.5.2
+
+-------------------------------------------------------------------
 Wed Apr 27 08:47:46 UTC 2022 - Noel Power <nopower@suse.com>
 
 - Use translation macro for range settings expert details text;

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - Samba Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/Samba.rb
+++ b/src/modules/Samba.rb
@@ -912,7 +912,8 @@ module Yast
       if WritePAMMount() &&
           Ops.greater_than(Builtins.size(@pam_mount_volumes), 0)
         # enable pam_mount for services gdm, xdm, login, sshd (bnc#433845)
-        Builtins.foreach(["gdm", "login", "xdm", "sshd"]) do |service|
+        # and gdm-password (bsc#1204830)
+        Builtins.foreach(["gdm", "gdm-password", "login", "xdm", "sshd"]) do |service|
           out = Convert.to_map(
             SCR.Execute(
               path(".target.bash_output"),


### PR DESCRIPTION
## Problem

The /etc/pam.d/gdm-password PAM service was a symlink to /etc/pam.d/gdm, but after the changes to  use %_pam_vendordir instead of %_distconfdir/pam.d (boo#1195996) the symlink is now in /usr/lib/pam.d so pam_mount has to be explicitly enabled for this service now.

Bugzilla link: https://bugzilla.suse.com/show_bug.cgi?id=1204830


## Solution

Enable pam-mount module for gdm-password service explicitly.


## Testing

- *Tested manually*


