### PR TITLE
Install samba-gpupdate when enabling Group Policy

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 19 19:12:38 UTC 2023 - David Mulder <dmulder@suse.com>
+
+- Install samba-gpupdate when enabling Group Policy; (bsc#1207604).
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Samba Client Configuration
 License:        GPL-2.0-only

--- a/src/include/samba-client/dialogs.rb
+++ b/src/include/samba-client/dialogs.rb
@@ -772,6 +772,14 @@ module Yast
                 :to   => "list <string>"
               )
             end
+            use_group_policy = UI.QueryWidget(Id(:gpupdate), :Value)
+            if use_group_policy
+              packages = Convert.convert(
+                Builtins.merge(packages, ["samba-gpupdate"]),
+                :from => "list",
+                :to   => "list <string>"
+              )
+            end
             if Samba.PAMMountModified &&
                 Ops.greater_than(Builtins.size(Samba.GetPAMMountVolumes), 0)
               packages = Builtins.add(packages, "pam_mount")


### PR DESCRIPTION
If the check box is selected to enable Group
Policy on the client, then we should ensure that
samba-gpupdate is installed so that Winbind can
apply policy.

