### PR TITLE
Fix yast net join

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 28 09:51:46 UTC 2025 - Noel Power <nopower@suse.com>
+
+- Fix on AD join error "Failed to join domain: failed to create
+  kerberos keytab"; (bsc#1238063);(bso#15727).
+- 5.0.1
+
+-------------------------------------------------------------------
 Mon Feb  3 09:40:11 UTC 2025 - Samuel Cabrero <scabrero@suse.de>
 
 - Remove nscd-related code (bsc#1236308)

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 Summary:        YaST2 - Samba Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/SambaNetJoin.pm
+++ b/src/modules/SambaNetJoin.pm
@@ -310,7 +310,7 @@ sub Join {
 	$glb_overrides{"create krb5 conf"} = "no";
 
 	$cmd		= "KRB5_CONFIG=$krb_file ";
-	SCR->Write (".target.string", $krb_file, "[realms]\n\t$realm = {\n\tkdc = $server\n\t}\n");
+	SCR->Write (".target.string", $krb_file, "[libdefaults]\n\tdefault_realm = $realm\n[realms]\n\t$realm = {\n\tkdc = $server\n\t}\n");
     }
     else {
 	$glb_overrides{"realm"} = undef;


### PR DESCRIPTION
## Problem

Attempt to join Windows AD domain with yast samba-client module results in "Failed to join domain: failed to create kerberos keytab"

- https://bugzilla.suse.com/show_bug.cgi?id=1238063 
- https://bugzilla.samba.org/show_bug.cgi?id=15727

## Solution

Add libdefaults section which contains a default_realm definition