### PR TITLE
Fix yast net join sl15sp7

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 28 09:56:45 UTC 2025 - Noel Power <nopower@suse.com>
+
+- Fix on AD join error "Failed to join domain: failed to create
+  kerberos keytab"; (bsc#1238063);(bso#15727).
+- 4.7.1
+
+-------------------------------------------------------------------
 Fri Sep 13 08:04:45 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Branch package for SP7 (bsc#1230201)

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        4.7.0
+Version:        4.7.1
 Release:        0
 Summary:        YaST2 - Samba Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/SambaNetJoin.pm
+++ b/src/modules/SambaNetJoin.pm
@@ -310,7 +310,7 @@ sub Join {
 	$glb_overrides{"create krb5 conf"} = "no";
 
 	$cmd		= "KRB5_CONFIG=$krb_file ";
-	SCR->Write (".target.string", $krb_file, "[realms]\n\t$realm = {\n\tkdc = $server\n\t}\n");
+	SCR->Write (".target.string", $krb_file, "[libdefaults]\n\tdefault_realm = $realm\n[realms]\n\t$realm = {\n\tkdc = $server\n\t}\n");
     }
     else {
 	$glb_overrides{"realm"} = undef;


### PR DESCRIPTION
## Problem

Attempt to join Windows AD domain with yast samba-client module results in "Failed to join domain: failed to create kerberos keytab"

- https://bugzilla.suse.com/show_bug.cgi?id=1238063 
- https://bugzilla.samba.org/show_bug.cgi?id=15727

## Solution

Add libdefaults section which contains a default_realm definition