### PR TITLE
Fix yast samba-client using aegues breaking nsswitch.conf

### DIFF
--- a/package/yast2-samba-client.changes
+++ b/package/yast2-samba-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 22 11:00:39 UTC 2025 - Noel Power <nopower@suse.com>
+
+- Avoid bsc#1222564 which breaks nsswitch.conf by instead adjusting
+  nsswitch.conf using sed rather than yast Nsswitch module using
+  augeas; (bsc#1222564.
+- 5.0.3
+
+-------------------------------------------------------------------
 Fri Feb 28 09:51:46 UTC 2025 - Noel Power <nopower@suse.com>
 
 - Fix on AD join error "Failed to join domain: failed to create

--- a/package/yast2-samba-client.spec
+++ b/package/yast2-samba-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-samba-client
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 Summary:        YaST2 - Samba Client Configuration
 License:        GPL-2.0-only

--- a/src/modules/SambaWinbind.pm
+++ b/src/modules/SambaWinbind.pm
@@ -10,7 +10,7 @@ package SambaWinbind;
 
 use strict;
 use Data::Dumper;
-
+use File::Copy;
 use YaST::YCP qw(:DATA :LOGGING);
 use YaPI;
 
@@ -81,19 +81,31 @@ sub AdjustSambaConfig {
 BEGIN{$TYPEINFO{AdjustNsswitch}=["function","boolean","boolean","boolean"]}
 sub AdjustNsswitch {
     my ($self, $on, $write_only) = @_;
+    my $etcnsswitch = "/etc/nsswitch.conf";
+    my $usretcnsswitch = "/usr/etc/nsswitch.conf";
+    my $cmd;
+    my $ret;
 
+    if (!-f $etcnsswitch) {
+	   copy($usretcnsswitch, $etcnsswitch);
+    }
     foreach my $db ("passwd", "group") {
-	my $nsswitch = Nsswitch->ReadDb($db);
 	if ($on) {
-	    push @$nsswitch, "winbind" unless grep {$_ eq "winbind"} @$nsswitch;
+		$cmd = "sed -i '/.*winbind.*\$/! s/^$db:.*\$/& winbind/' $etcnsswitch";
 	} else {
-	    @$nsswitch = grep {$_ ne "winbind"} @$nsswitch;
+		$cmd = "sed -i '/^$db:.*winbind.*/ s/ *winbind//g' $etcnsswitch";
 	}
-	y2debug("Nsswitch->WriteDB($db, ".Dumper($nsswitch).")");
-	Nsswitch->WriteDb($db, $nsswitch);
+	my $result = SCR->Execute(".target.bash_output", $cmd);
+        if ($result->{"exit"} ne 0) {
+            y2debug ("sed %s failed, output: %s", $cmd, Dumper ($result));
+            $ret = FALSE;
+	    last;
+        } else  {
+            $ret = TRUE;
+        }
     };
-    my $ret = Nsswitch->Write();
-    y2error("Nsswitch->Write() failed") if (!$ret);
+
+    y2error("update to %s failed", $etcnsswitch) if (!$ret);
 
     # restart zmd (#174589)
     if (!$write_only && PackageSystem->Installed ("zmd") &&


### PR DESCRIPTION
## yast samba-client using yast Nsswitch module can break nsswitch.conf

* yast samba-client updating nsswitch.conf  via /usr/share/YaST2/modules/Nsswitch.rb can break nsswitch.conf when  nsswitch.conf contains an optional action column

- https://bugzilla.suse.com/show_bug.cgi?id=1222564